### PR TITLE
chore: added node class constraint

### DIFF
--- a/axiomatic.nomad
+++ b/axiomatic.nomad
@@ -3,6 +3,10 @@ job "axiomatic" {
     repo = "http://github.com/code42/axiomatic"
     service = "axiomatic"
   }
+  constraint {
+    attribute = "${node.class}"
+    value     = "default"
+  }
   datacenters = ["dc1"]
   group "axiomatic" {
     task "axiomatic" {


### PR DESCRIPTION
The original axiomatic job would be scheduled on any available nomad client.  With the addition of the privileged runner client cluster (and node class), adding a constraint to limit the job to the non-privileged nodes is needed.