### PR TITLE
chore: limit launched dir2consul job to default nodes

### DIFF
--- a/nomad.go
+++ b/nomad.go
@@ -1,71 +1,75 @@
 package main
 
 import (
-	"bytes"
-	"errors"
-	"log"
+    "bytes"
+    "errors"
+    "log"
 
-	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/nomad/jobspec"
+    "github.com/hashicorp/nomad/api"
+    "github.com/hashicorp/nomad/jobspec"
 )
 
 // NomadJobData contains data for job template rendering
 type NomadJobData struct {
-	GitRepoName string
-	GitRepoURL  string
-	HeadSHA     string
-	DeployKey   string
-	Environment map[string]string
+    GitRepoName string
+    GitRepoURL  string
+    HeadSHA     string
+    DeployKey   string
+    Environment map[string]string
 }
 
 func templateToJob(jobArgs NomadJobData) (*api.Job, error) {
-	var buf bytes.Buffer
+    var buf bytes.Buffer
 
-	// execute template with given data and output to io pipe
-	err := jobTemplate.Execute(&buf, jobArgs)
-	if err != nil {
-		return nil, err
-	}
+    // execute template with given data and output to io pipe
+    err := jobTemplate.Execute(&buf, jobArgs)
+    if err != nil {
+        return nil, err
+    }
 
-	// create a Nomad job struct by parsing data from the io pipe
-	var job *api.Job
-	job, err = jobspec.Parse(&buf)
-	if err != nil {
-		return nil, err
-	}
+    // create a Nomad job struct by parsing data from the io pipe
+    var job *api.Job
+    job, err = jobspec.Parse(&buf)
+    if err != nil {
+        return nil, err
+    }
 
-	return job, nil
+    return job, nil
 }
 
 // submitNomadJob sends a job to a Nomad server
 func submitNomadJob(job *api.Job) error {
-	nomadClient, err := api.NewClient(api.DefaultConfig())
-	if err != nil {
-		log.Println("Error establishing Nomad Client:", err)
-		return err
-	}
+    nomadClient, err := api.NewClient(api.DefaultConfig())
+    if err != nil {
+        log.Println("Error establishing Nomad Client:", err)
+        return err
+    }
 
-	var jobResp *api.JobRegisterResponse
-	jobResp, _, err = nomadClient.Jobs().Register(job, nil)
-	if err != nil {
-		return err
-	}
-	if jobResp == (*api.JobRegisterResponse)(nil) {
-		return errors.New("jobResp is nil")
-	}
-	if jobResp.Warnings != "" {
-		log.Printf("Nomad job response: %+v", jobResp)
-		return errors.New(jobResp.Warnings)
-	}
+    var jobResp *api.JobRegisterResponse
+    jobResp, _, err = nomadClient.Jobs().Register(job, nil)
+    if err != nil {
+        return err
+    }
+    if jobResp == (*api.JobRegisterResponse)(nil) {
+        return errors.New("jobResp is nil")
+    }
+    if jobResp.Warnings != "" {
+        log.Printf("Nomad job response: %+v", jobResp)
+        return errors.New(jobResp.Warnings)
+    }
 
-	return nil
+    return nil
 }
 
 // templateNomadJob returns a Nomad job definition as a string
 func templateNomadJob() string {
-	const jobTemplate = `
+    const jobTemplate = `
 job "dir2consul-{{ .GitRepoName }}" {
     datacenters = ["dc1"]
+    constraint {
+        attribute = "${node.class}"
+        value     = "default"
+    }
     region = "global"
     group "dir2consul" {
         task "dir2consul" {
@@ -109,5 +113,5 @@ job "dir2consul-{{ .GitRepoName }}" {
     type = "batch"
 }
 `
-	return jobTemplate
+    return jobTemplate
 }


### PR DESCRIPTION
This is probably worth a discussion as to whether it's strictly wanted or needed.  It works fine as it is, but it also runs on nodes with permissions it doesn't need, and it probably shouldn't.