### PR TITLE
build: add dependabot workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Let's reduce the number of clicks necessary to accept dependabot PRs. This makes handling PRs faster and less burdensome.

This workflow enables the auto-merge setting on dependabot PRs. Consequently, a reviewer now only needs to approve the PR and the merge happens automatically. While this may seem like saving a trivial amount of work/time, dependabot PRs can be frequent and obligating reviewers to do unnecessary work is wasteful when it can be automated/eliminated.